### PR TITLE
Buzas sprint2 plant service 30.03.23 3:39 (MSK)

### DIFF
--- a/module.plant-service/build.gradle
+++ b/module.plant-service/build.gradle
@@ -20,12 +20,16 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.0.5'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web:3.0.5'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
+    implementation 'com.h2database:h2'
+    implementation 'org.projectlombok:lombok:1.18.24'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.5'
+    testImplementation 'junit:junit'
+    annotationProcessor 'org.projectlombok:lombok'
 }
 
 test {

--- a/module.plant-service/src/main/java/ru/botanica/PlantServiceApplication.java
+++ b/module.plant-service/src/main/java/ru/botanica/PlantServiceApplication.java
@@ -2,8 +2,10 @@ package ru.botanica;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
+@EnableJpaRepositories
 public class PlantServiceApplication {
 
     public static void main(String[] args) {

--- a/module.plant-service/src/main/java/ru/botanica/controllers/PlantController.java
+++ b/module.plant-service/src/main/java/ru/botanica/controllers/PlantController.java
@@ -1,0 +1,33 @@
+package ru.botanica.controllers;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import ru.botanica.entities.plants.PlantDto;
+import ru.botanica.services.PlantService;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/plants")
+@RequiredArgsConstructor
+@Slf4j
+public class PlantController {
+    private final PlantService plantService;
+    private final int PAGE_SIZE = 10;
+
+    @GetMapping()
+    public Page<PlantDto> findAllByFilters(@RequestParam(required = false, defaultValue = "1")Optional<Integer> page,
+                                           @RequestParam(required = false) String title) {
+//
+        int currentPage = page.orElse(1) - 1;
+        int sizeValue = PAGE_SIZE;
+        return plantService.findAll(title, PageRequest.of(currentPage, sizeValue));
+    }
+}

--- a/module.plant-service/src/main/java/ru/botanica/controllers/PlantController.java
+++ b/module.plant-service/src/main/java/ru/botanica/controllers/PlantController.java
@@ -25,7 +25,6 @@ public class PlantController {
     @GetMapping()
     public Page<PlantDto> findAllByFilters(@RequestParam(required = false, defaultValue = "1")Optional<Integer> page,
                                            @RequestParam(required = false) String title) {
-//
         int currentPage = page.orElse(1) - 1;
         int sizeValue = PAGE_SIZE;
         return plantService.findAll(title, PageRequest.of(currentPage, sizeValue));

--- a/module.plant-service/src/main/java/ru/botanica/controllers/PlantController.java
+++ b/module.plant-service/src/main/java/ru/botanica/controllers/PlantController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.RestController;
 import ru.botanica.entities.plants.PlantDto;
 import ru.botanica.services.PlantService;
 
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/plants")
@@ -23,9 +22,9 @@ public class PlantController {
     private final int PAGE_SIZE = 10;
 
     @GetMapping()
-    public Page<PlantDto> findAllByFilters(@RequestParam(required = false, defaultValue = "1")Optional<Integer> page,
+    public Page<PlantDto> findAllByFilters(@RequestParam(required = false, defaultValue = "1")int page,
                                            @RequestParam(required = false) String title) {
-        int currentPage = page.orElse(1) - 1;
+        int currentPage = page - 1;
         int sizeValue = PAGE_SIZE;
         return plantService.findAll(title, PageRequest.of(currentPage, sizeValue));
     }

--- a/module.plant-service/src/main/java/ru/botanica/entities/photos/PlantPhoto.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/photos/PlantPhoto.java
@@ -1,0 +1,35 @@
+package ru.botanica.entities.photos;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+//  TODO: !!!добавление этой сущности вызвало уничтожение данных в таблице plant_photos при инициализации приложения. ИСПРАВИТЬ!!!
+@Entity
+@Getter
+@Setter
+@Table(schema = "simple_botanica", name = "plant_photos")
+public class PlantPhoto {
+    @Id
+    @Column(name = "plant_id")
+    private Long id;
+
+    @Column(name = "file_path")
+    private String filePath;
+
+    public PlantPhoto(String filePath, Long id) {
+        this.filePath = filePath;
+        this.id = id;
+    }
+
+    public PlantPhoto() {
+    }
+
+    @Override
+    public String toString() {
+        return "PlantPhoto{" +
+                "id=" + id +
+                ", filePath='" + filePath + '\'' +
+                '}';
+    }
+}

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/Plant.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/Plant.java
@@ -38,6 +38,8 @@ public class Plant {
     @Column(nullable = false, name = "is_active")
     private boolean isActive;
 
+    private String filePath;
+
     public Plant() {
     }
 
@@ -50,7 +52,8 @@ public class Plant {
                 ", genus='" + genus + '\'' +
                 ", description='" + description + '\'' +
                 ", shortDescription='" + shortDescription + '\'' +
-                ", isActive=" + isActive +
+                ", isActive=" + isActive + '\'' +
+                ", filePath=" + filePath +
                 '}';
     }
 }

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/Plant.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/Plant.java
@@ -3,13 +3,8 @@ package ru.botanica.entities.plants;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import ru.botanica.entities.photos.PlantPhoto;
 
-// TODO: После привязки к БД, скрипт инициализации БД начал выдавать две ошибки о том, что не может изменить данную таблицу, а именно:
-//  Error executing DDL "drop table if exists plants" via JDBC Statement и
-//  Error executing DDL "create table plants (plant_id bigint not null auto_increment, description varchar(255) not null, family varchar(128) not null,
-//  genus varchar(128) not null, is_active bit not null, name varchar(128) not null, short_description varchar(128) not null,
-//  primary key (plant_id)) engine=InnoDB" via JDBC Statement . Нагуглить решение или исправить сам не смог.
-//  Не смотря на ошибки, работоспособность сохраняется
 @Entity
 @Getter
 @Setter
@@ -38,7 +33,9 @@ public class Plant {
     @Column(nullable = false, name = "is_active")
     private boolean isActive;
 
-    private String filePath;
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "plant_id")
+    private PlantPhoto photo;
 
     public Plant() {
     }
@@ -53,7 +50,7 @@ public class Plant {
                 ", description='" + description + '\'' +
                 ", shortDescription='" + shortDescription + '\'' +
                 ", isActive=" + isActive + '\'' +
-                ", filePath=" + filePath +
+                ", filePath=" + photo.getFilePath() +
                 '}';
     }
 }

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/Plant.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/Plant.java
@@ -1,0 +1,56 @@
+package ru.botanica.entities.plants;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+// TODO: После привязки к БД, скрипт инициализации БД начал выдавать две ошибки о том, что не может изменить данную таблицу, а именно:
+//  Error executing DDL "drop table if exists plants" via JDBC Statement и
+//  Error executing DDL "create table plants (plant_id bigint not null auto_increment, description varchar(255) not null, family varchar(128) not null,
+//  genus varchar(128) not null, is_active bit not null, name varchar(128) not null, short_description varchar(128) not null,
+//  primary key (plant_id)) engine=InnoDB" via JDBC Statement . Нагуглить решение или исправить сам не смог.
+//  Не смотря на ошибки, работоспособность сохраняется
+@Entity
+@Getter
+@Setter
+@Table(schema = "simple_botanica", name = "plants")
+public class Plant {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "plant_id")
+    private Long id;
+
+    @Column(nullable = false, length = 128, name = "name")
+    private String name;
+
+    @Column(nullable = false, length = 128, name = "family")
+    private String family;
+
+    @Column(nullable = false, length = 128, name = "genus")
+    private String genus;
+
+    @Column(nullable = false, name = "description")
+    private String description;
+
+    @Column(nullable = false, length = 128, name = "short_description")
+    private String shortDescription;
+
+    @Column(nullable = false, name = "is_active")
+    private boolean isActive;
+
+    public Plant() {
+    }
+
+    @Override
+    public String toString() {
+        return "Plant{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", family='" + family + '\'' +
+                ", genus='" + genus + '\'' +
+                ", description='" + description + '\'' +
+                ", shortDescription='" + shortDescription + '\'' +
+                ", isActive=" + isActive +
+                '}';
+    }
+}

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDto.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDto.java
@@ -1,0 +1,36 @@
+package ru.botanica.entities.plants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Component
+public class PlantDto {
+    private Long id;
+    private String name;
+    private String family;
+    private String genus;
+    private String description;
+    private String shortDescription;
+    private boolean isActive;
+
+    public PlantDto() {
+    }
+
+    @Override
+    public String toString() {
+        return "PlantDto{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", family='" + family + '\'' +
+                ", genus='" + genus + '\'' +
+                ", description='" + description + '\'' +
+                ", shortDescription='" + shortDescription + '\'' +
+                ", isActive=" + isActive +
+                '}';
+    }
+}

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDto.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDto.java
@@ -18,6 +18,8 @@ public class PlantDto {
     private String shortDescription;
     private boolean isActive;
 
+    private String filePath;
+
     public PlantDto() {
     }
 

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDto.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDto.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.stereotype.Component;
 
+import java.util.Objects;
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -32,7 +34,21 @@ public class PlantDto {
                 ", genus='" + genus + '\'' +
                 ", description='" + description + '\'' +
                 ", shortDescription='" + shortDescription + '\'' +
-                ", isActive=" + isActive +
+                ", isActive=" + isActive + '\'' +
+                ", filePath=" + filePath +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PlantDto plantDto = (PlantDto) o;
+        return isActive == plantDto.isActive && Objects.equals(id, plantDto.id) && Objects.equals(name, plantDto.name) && Objects.equals(family, plantDto.family) && Objects.equals(genus, plantDto.genus) && Objects.equals(description, plantDto.description) && Objects.equals(shortDescription, plantDto.shortDescription) && Objects.equals(filePath, plantDto.filePath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, family, genus, description, shortDescription, isActive, filePath);
     }
 }

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDtoMap.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDtoMap.java
@@ -1,0 +1,19 @@
+package ru.botanica.entities.plants;
+
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class PlantDtoMap {
+    private final Map<Long, PlantDto> plantDtoMap = new HashMap<>();
+
+    public void addPlant(PlantDto plantDto) {
+        plantDtoMap.put(plantDto.getId(), plantDto);
+    }
+
+    public PlantDto getPlant(Long id) {
+        return plantDtoMap.get(id);
+    }
+}

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDtoMapper.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDtoMapper.java
@@ -1,0 +1,30 @@
+package ru.botanica.entities.plants;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PlantDtoMapper {
+    public Plant map(PlantDto plantDto) {
+        Plant plant = new Plant();
+        plant.setId(plantDto.getId());
+        plant.setName(plantDto.getName());
+        plant.setFamily(plantDto.getFamily());
+        plant.setGenus(plantDto.getGenus());
+        plant.setDescription(plantDto.getDescription());
+        plant.setShortDescription(plantDto.getShortDescription());
+        plant.setActive(plantDto.isActive());
+        return plant;
+    }
+
+    public PlantDto map(Plant plant) {
+        PlantDto plantDto = new PlantDto();
+        plantDto.setId(plant.getId());
+        plantDto.setName(plant.getName());
+        plantDto.setFamily(plant.getFamily());
+        plantDto.setGenus(plant.getGenus());
+        plantDto.setDescription(plant.getDescription());
+        plantDto.setShortDescription(plant.getShortDescription());
+        plantDto.setActive(plant.isActive());
+        return plantDto;
+    }
+}

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDtoMapper.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDtoMapper.java
@@ -13,6 +13,7 @@ public class PlantDtoMapper {
         plant.setDescription(plantDto.getDescription());
         plant.setShortDescription(plantDto.getShortDescription());
         plant.setActive(plantDto.isActive());
+        plant.setFilePath(plantDto.getFilePath());
         return plant;
     }
 
@@ -25,6 +26,16 @@ public class PlantDtoMapper {
         plantDto.setDescription(plant.getDescription());
         plantDto.setShortDescription(plant.getShortDescription());
         plantDto.setActive(plant.isActive());
+        plantDto.setFilePath(plant.getFilePath());
+        return plantDto;
+    }
+
+    public PlantDto mapWithIdNameShortDescAndFilePath(Plant plant) {
+        PlantDto plantDto = new PlantDto();
+        plantDto.setId(plant.getId());
+        plantDto.setName(plant.getName());
+        plantDto.setShortDescription(plant.getShortDescription());
+        plantDto.setFilePath(plant.getFilePath());
         return plantDto;
     }
 }

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDtoMapper.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantDtoMapper.java
@@ -1,10 +1,11 @@
 package ru.botanica.entities.plants;
 
 import org.springframework.stereotype.Component;
+import ru.botanica.entities.photos.PlantPhoto;
 
 @Component
 public class PlantDtoMapper {
-    public Plant map(PlantDto plantDto) {
+    public Plant mapToEntity(PlantDto plantDto) {
         Plant plant = new Plant();
         plant.setId(plantDto.getId());
         plant.setName(plantDto.getName());
@@ -13,11 +14,12 @@ public class PlantDtoMapper {
         plant.setDescription(plantDto.getDescription());
         plant.setShortDescription(plantDto.getShortDescription());
         plant.setActive(plantDto.isActive());
-        plant.setFilePath(plantDto.getFilePath());
+//        TODO: проверить на ошибки в более готовой версии
+        plant.setPhoto(new PlantPhoto(plantDto.getFilePath(), plantDto.getId()));
         return plant;
     }
 
-    public PlantDto map(Plant plant) {
+    public PlantDto mapToDto(Plant plant) {
         PlantDto plantDto = new PlantDto();
         plantDto.setId(plant.getId());
         plantDto.setName(plant.getName());
@@ -26,16 +28,16 @@ public class PlantDtoMapper {
         plantDto.setDescription(plant.getDescription());
         plantDto.setShortDescription(plant.getShortDescription());
         plantDto.setActive(plant.isActive());
-        plantDto.setFilePath(plant.getFilePath());
+        plantDto.setFilePath(plant.getPhoto().getFilePath());
         return plantDto;
     }
 
-    public PlantDto mapWithIdNameShortDescAndFilePath(Plant plant) {
+    public PlantDto mapToDtoWithIdNameShortDescAndFilePath(Plant plant) {
         PlantDto plantDto = new PlantDto();
         plantDto.setId(plant.getId());
         plantDto.setName(plant.getName());
         plantDto.setShortDescription(plant.getShortDescription());
-        plantDto.setFilePath(plant.getFilePath());
+        plantDto.setFilePath(plant.getPhoto().getFilePath());
         return plantDto;
     }
 }

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantRepository.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantRepository.java
@@ -1,0 +1,21 @@
+package ru.botanica.entities.plants;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlantRepository extends JpaRepository<Plant, Long> {
+    @Query(
+            value = """
+                        select * from plants p
+                        where (:name is null or p.name like :name)
+""", countQuery = """
+                        select * from plants p
+                        where (:name is null or p.name like :name)
+""", nativeQuery = true
+    )
+    Page<Plant> findAllByNameContains(String name, Pageable pageable);
+}

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantRepository.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantRepository.java
@@ -1,23 +1,9 @@
 package ru.botanica.entities.plants;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PlantRepository extends JpaRepository<Plant, Long> {
-    @Query(
-            value = """
-                        select p.*, pp.file_path from plants p
-                        inner join plant_photos pp on p.plant_id = pp.plant_id
-                        where (:name is null or p.name like :name)
-""", countQuery = """
-                        select p.*, pp.file_path from plants p
-                        inner join plant_photos pp on p.plant_id = pp.plant_id
-                        where (:name is null or p.name like :name)
-""", nativeQuery = true
-    )
-    Page<Plant> findAllByNameContains(String name, Pageable pageable);
+public interface PlantRepository extends JpaRepository<Plant, Long>, JpaSpecificationExecutor<Plant> {
 }

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantRepository.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantRepository.java
@@ -10,12 +10,14 @@ import org.springframework.stereotype.Repository;
 public interface PlantRepository extends JpaRepository<Plant, Long> {
     @Query(
             value = """
-                        select p from Plant p
+                        select p.*, pp.file_path from plants p
+                        inner join plant_photos pp on p.plant_id = pp.plant_id
                         where (:name is null or p.name like :name)
 """, countQuery = """
-                        select p from Plant p
+                        select p.*, pp.file_path from plants p
+                        inner join plant_photos pp on p.plant_id = pp.plant_id
                         where (:name is null or p.name like :name)
-"""
+""", nativeQuery = true
     )
     Page<Plant> findAllByNameContains(String name, Pageable pageable);
 }

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantRepository.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantRepository.java
@@ -10,12 +10,12 @@ import org.springframework.stereotype.Repository;
 public interface PlantRepository extends JpaRepository<Plant, Long> {
     @Query(
             value = """
-                        select * from plants p
+                        select p from Plant p
                         where (:name is null or p.name like :name)
 """, countQuery = """
-                        select * from plants p
+                        select p from Plant p
                         where (:name is null or p.name like :name)
-""", nativeQuery = true
+"""
     )
     Page<Plant> findAllByNameContains(String name, Pageable pageable);
 }

--- a/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantSpecifications.java
+++ b/module.plant-service/src/main/java/ru/botanica/entities/plants/PlantSpecifications.java
@@ -1,0 +1,10 @@
+package ru.botanica.entities.plants;
+
+import org.springframework.data.jpa.domain.Specification;
+
+public class PlantSpecifications {
+    public static Specification<Plant> nameLike(String title) {
+        return (root, criteriaQuery, criteriaBuilder) ->
+                criteriaBuilder.like(root.get("name"), "%" + title + "%");
+    }
+}

--- a/module.plant-service/src/main/java/ru/botanica/services/PlantService.java
+++ b/module.plant-service/src/main/java/ru/botanica/services/PlantService.java
@@ -20,10 +20,10 @@ public class PlantService {
 //          TODO: придумать костыль получше
 //        Костыль, но он улучшает поиск, добавляя все возможные варианты даже если название введено не полностью
         if (title == null) {
-            return plantRepository.findAllByNameContains(title, pageable).map(plantDtoMapper::map);
+            return plantRepository.findAllByNameContains(title, pageable).map(plantDtoMapper::mapWithIdNameShortDescAndFilePath);
         } else {
             String resultTitle = "%" + title + "%";
-            return plantRepository.findAllByNameContains(resultTitle, pageable).map(plantDtoMapper::map);
+            return plantRepository.findAllByNameContains(resultTitle, pageable).map(plantDtoMapper::mapWithIdNameShortDescAndFilePath);
         }
     }
 }

--- a/module.plant-service/src/main/java/ru/botanica/services/PlantService.java
+++ b/module.plant-service/src/main/java/ru/botanica/services/PlantService.java
@@ -1,0 +1,29 @@
+package ru.botanica.services;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import ru.botanica.entities.plants.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PlantService {
+    private final PlantRepository plantRepository;
+    private final PlantDtoMapper plantDtoMapper;
+    private final PlantDtoMap plantDtoMap;
+
+
+    public Page<PlantDto> findAll(String title, Pageable pageable) {
+//          TODO: придумать костыль получше
+//        Костыль, но он улучшает поиск, добавляя все возможные варианты даже если название введено не полностью
+        if (title == null) {
+            return plantRepository.findAllByNameContains(title, pageable).map(plantDtoMapper::map);
+        } else {
+            String resultTitle = "%" + title + "%";
+            return plantRepository.findAllByNameContains(resultTitle, pageable).map(plantDtoMapper::map);
+        }
+    }
+}

--- a/module.plant-service/src/main/resources/application.properties
+++ b/module.plant-service/src/main/resources/application.properties
@@ -5,3 +5,4 @@ spring.datasource.username=root
 spring.datasource.password=root
 spring.jpa.hibernate.ddl-auto=create
 spring.flyway.baseline-on-migrate=true
+logging.level.ru.botanica=debug

--- a/module.plant-service/src/main/resources/application.properties
+++ b/module.plant-service/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 server.port = 8189
-server.servlet.context-path= /botanica
+server.servlet.context-path= /botanica/api
 spring.datasource.url=jdbc:mysql://localhost:3306/simple_botanica?createDatabaseIfNotExist=true&autoReconnect=true&useSSL=false&allowPublicKeyRetrieval=true
 spring.datasource.username=root
 spring.datasource.password=root
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.flyway.baseline-on-migrate=true
 logging.level.ru.botanica=debug


### PR DESCRIPTION
Согласно таблице контрактов добавил отправку страницы с ДТО растений. Т.к. в таблице на входные параметры отображено "title, page", вынес размер страницы из необязательных параметров в константы контроллера. Так же, т.к. требуется входной title, а не name(как в БД)- протащил title, но в репо оставил name, чтобы было более ясно, что происходит в запросе.
Слышал, что использованный мной способ обработки запросов(через Query в JPA) ресурсозатратен и не защищен от инъекций. Если потребуется, переделаю на связь view с БД.
При создании Entity, привязанной к таблице(в моем случае к plants), скрипт, написанный Алексеем начинает выдавать ошибки из-за невозможности удалять и создавать данную таблицу(ошибки не в Entity, работе приложения не мешает). Несмотря на данные ошибки последующий код приложения работает исправно. Ошибки перечислены в TODO Plant-класса.
Работа с Gradle вызвала ряд сложностей из-за нехватки опыта, потому время, отведенное в графике под тесты и дополнительные задачи было "съедено" попыткой устранить указанную выше ошибку и установкой правильных зависимостей для проекта. Их разработка была перенесена.
В проекте также оставлена заготовка под PlantDtoMap, из которой можно будет брать данные по растениям вместо БД
По графику продолжение работы в этой ветке планируется 31.03.23 с тратой всего рабочего дня на дальнейшую разработку и исправления после получения обратной связи

UPD: Добавил забытый по дороге путь к фото растения. Вернул nativeQuery, чтобы с методом можно было работать. Написал дополнительный метод в mapper, чтобы скидывать лишнюю инфу(до этого уходило вместе с полным описанием и активным флагом)