### PR TITLE
Добавлен обработчик ошибок в plant-service 27.04.23

### DIFF
--- a/module.plant-service/src/main/java/ru/botanica/controllers/GlobalExceptionHandler.java
+++ b/module.plant-service/src/main/java/ru/botanica/controllers/GlobalExceptionHandler.java
@@ -1,0 +1,99 @@
+package ru.botanica.controllers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.PropertyValueException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import ru.botanica.exceptions.PlantExistsException;
+import ru.botanica.exceptions.ServerHandleException;
+import ru.botanica.responses.AppResponse;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    /**
+     * Отлавливает ошибки, связанные с существованием или отсутствием растения в БД
+     *
+     * @param exception Ошибка
+     * @return Сообщение об ошибке
+     */
+    @ExceptionHandler
+    public ResponseEntity<?> catchPlantExistsException(PlantExistsException exception) {
+        log.error(exception.getMessage(), exception);
+        return new ResponseEntity<>(new AppResponse(HttpStatus.BAD_REQUEST.value(),
+                exception.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * Отлавливает ошибки, связанные с работой сервера (обработка данных,
+     * передача данных, запись данных, удаление данных)
+     *
+     * @param exception Ошибка
+     * @return Сообщение об ошибке
+     */
+    @ExceptionHandler
+    public ResponseEntity<?> catchServerHandleException(ServerHandleException exception) {
+        log.error(exception.getMessage(), exception);
+        return new ResponseEntity<>(new AppResponse(HttpStatus.UNPROCESSABLE_ENTITY.value(),
+                exception.getMessage()), HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * Отлавливает ошибки, связанные с неподдерживаемыми форматами файлов
+     *
+     * @param exception Ошибка
+     * @return Сообщение об ошибке
+     */
+    @ExceptionHandler
+    public ResponseEntity<?> catchHttpMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException exception) {
+        log.error(exception.getMessage(), exception);
+//        На всякий обратно на фронт не передаю реальные данные ошибки, а лишь прокидываю общую фразу, т.к.
+//        это стандартное исключение. Отлов исключений ниже сделан по такому же принципу
+        return new ResponseEntity<>(new AppResponse(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value(),
+                "Неподдерживаемый формат файлов"), HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    /**
+     * Отлавливает ошибки, связанные с невозможными значениями для полей
+     *
+     * @param exception Ошибка
+     * @return Сообщение об ошибке
+     */
+    @ExceptionHandler
+    public ResponseEntity<?> catchPropertyValueException(PropertyValueException exception) {
+        log.error(exception.getMessage(), exception);
+        return new ResponseEntity<>(new AppResponse(HttpStatus.BAD_REQUEST.value(),
+                "Указанные значения или их часть не могут быть null"), HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * Отлавливает ошибки, связанные с невозможностью сохранить значение в БД
+     *
+     * @param exception Ошибка
+     * @return Сообщение об ошибке
+     */
+    @ExceptionHandler
+    public ResponseEntity<?> catchDataIntegrityViolationException(DataIntegrityViolationException exception) {
+        log.error(exception.getMessage(), exception);
+        return new ResponseEntity<>(new AppResponse(HttpStatus.BAD_REQUEST.value(),
+                "Указанные значения или их часть не могут быть null"), HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * Отлавливает ошибки, связанные с null-значениями для обязательных полей, классов или параметров
+     *
+     * @param exception Ошибка
+     * @return Сообщение об ошибке
+     */
+    @ExceptionHandler
+    public ResponseEntity<?> catchNullPointerException(NullPointerException exception) {
+        log.error(exception.getMessage(), exception);
+        return new ResponseEntity<>(new AppResponse(HttpStatus.BAD_REQUEST.value(),
+                "Среди обязательных параметров для эндпоинта был прислан null"), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/module.plant-service/src/main/java/ru/botanica/controllers/PlantController.java
+++ b/module.plant-service/src/main/java/ru/botanica/controllers/PlantController.java
@@ -37,7 +37,7 @@ public class PlantController {
 //                                           Изначально помещается 10, но, чтобы при текущих данных в БД было
 //                                           две страницы, сместил значение по умолчанию до 8
                                                 @RequestParam(required = false, defaultValue = "8") int size,
-                                                @RequestParam(required = false) String title) {
+                                                @RequestParam(required = false) String title) throws Exception {
         int currentPage = page - 1;
         return plantService.findAll(title, PageRequest.of(currentPage, size));
     }
@@ -49,7 +49,7 @@ public class PlantController {
      * @return Растение
      */
     @GetMapping("/plant/{id}")
-    public PlantDto findById(@PathVariable long id) {
+    public PlantDto findById(@PathVariable long id) throws Exception {
         return plantService.findById(id);
     }
 
@@ -60,29 +60,12 @@ public class PlantController {
      * @return responseEntity с кодом и сообщением
      */
     @PutMapping("/plant")
-    public ResponseEntity<?> updateById(@RequestBody PlantDto plantDto) {
-        Long id = plantDto.getId();
-        if (!plantService.isIdExist(id)) {
-//            Если растение не существует
-            log.error("Растения не существует, id: {}", id);
-            log.error(plantDto.toString());
-            return new ResponseEntity<>(new AppResponse(HttpStatus.BAD_REQUEST.value(),
-                    "Растение не существует, id- " + id), HttpStatus.BAD_REQUEST);
-        } else {
-            try {
-                plantService.updatePlant(plantDto);
-            } catch (Exception e) {
-//                Неудачное обновление
-                log.error("Сервер не смог обновить растение с id {}", id);
-                log.error(plantDto.toString());
-                return new ResponseEntity<>(new AppResponse(HttpStatus.UNPROCESSABLE_ENTITY.value(),
-                        "Сервер не смог обновить растение с id " + id), HttpStatus.UNPROCESSABLE_ENTITY);
-            }
-//            Удачное обновление
-            log.debug("Растение обновлено, id {}", id);
-            return new ResponseEntity<>(new AppResponse(HttpStatus.OK.value(),
-                    "Растение обновлено, id: " + id), HttpStatus.OK);
-        }
+    public ResponseEntity<?> updateById(@RequestBody PlantDto plantDto) throws Exception {
+        log.debug("Попытка обновления, входящие данные: {}", plantDto.toString());
+        plantService.updatePlant(plantDto);
+        log.debug("Растение обновлено, id {}", plantDto.getId());
+        return new ResponseEntity<>(new AppResponse(HttpStatus.OK.value(),
+                "Растение обновлено, id: " + plantDto.getId()), HttpStatus.OK);
     }
 
     /**
@@ -94,28 +77,13 @@ public class PlantController {
      */
     @PostMapping("/plant")
     public ResponseEntity<?> addPlant(@RequestBody PlantDto plantDto,
-                                      @RequestParam(name = "isOverwriting", defaultValue = "false") boolean isOverwriting) {
-        if (plantService.findByName(plantDto.getName()).isPresent() && !isOverwriting) {
-//            Если растение существует и его нельзя перезаписывать
-            log.warn("Растение с именем {} уже существует и его нельзя перезаписать", plantDto.getName());
-            log.error(plantDto.toString());
-            return new ResponseEntity<>(new AppResponse(HttpStatus.BAD_REQUEST.value(),
-                    "Растение с таким именем существует"), HttpStatus.BAD_REQUEST);
-        } else {
-            try {
-                plantService.addNewPlant(plantDto, isOverwriting);
-            } catch (Exception e) {
-//                Неудачное сохранение растения
-                log.error("Сервер не смог сохранить растение с именем: {}", plantDto.getName());
-                log.error(plantDto.toString());
-                return new ResponseEntity<>(new AppResponse(HttpStatus.UNPROCESSABLE_ENTITY.value(),
-                        "Сервер не смог добавить растение"), HttpStatus.UNPROCESSABLE_ENTITY);
-            }
-//            Удачное сохранение
-            log.debug("Растение создано, имя: {}", plantDto.getName());
-            return new ResponseEntity<>(new AppResponse(HttpStatus.OK.value(),
-                    "Растение создано, имя: " + plantDto.getName()), HttpStatus.OK);
-        }
+                                      @RequestParam(name = "isOverwriting", defaultValue = "false") boolean isOverwriting) throws Exception {
+        log.debug("Попытка сохранения: {}", plantDto.toString());
+        plantService.addNewPlant(plantDto, isOverwriting);
+        log.debug("Растение создано, имя: {}", plantDto.getName());
+        return new ResponseEntity<>(new AppResponse(HttpStatus.OK.value(),
+                "Растение создано, имя: " + plantDto.getName()), HttpStatus.OK);
+
     }
 
     /**
@@ -125,26 +93,12 @@ public class PlantController {
      * @return responseEntity с кодом и сообщением
      */
     @DeleteMapping("plant/{id}")
-    public ResponseEntity<?> deletePlant(@PathVariable long id) {
-        if (!plantService.isIdExist(id)) {
-//            Если растение не существует
-            log.error("Растения с id {} не существует", id);
-            return new ResponseEntity<>(new AppResponse(HttpStatus.BAD_REQUEST.value(),
-                    "Растение не существует, id- " + id), HttpStatus.BAD_REQUEST);
-        } else {
-            try {
-                plantService.deletePlantById(id);
-            } catch (Exception e) {
-//                Неудачное удаление
-                log.error("Проблема у сервера с удалением id: {}", id);
-                return new ResponseEntity<>(new AppResponse(HttpStatus.UNPROCESSABLE_ENTITY.value(),
-                        "Сервер не смог удалить растение с id " + id), HttpStatus.UNPROCESSABLE_ENTITY);
-            }
-//            Удачное удаление
-            log.debug("Удаление успешно, id: {}", id);
-            return new ResponseEntity<>(new AppResponse(HttpStatus.OK.value(),
-                    "Растение удалено, id: " + id), HttpStatus.OK);
-        }
+    public ResponseEntity<?> deletePlant(@PathVariable long id) throws Exception {
+        log.debug("Попытка удаления по id: {}", id);
+        plantService.deletePlantById(id);
+        log.debug("Удаление успешно, id: {}", id);
+        return new ResponseEntity<>(new AppResponse(HttpStatus.OK.value(),
+                "Растение удалено, id: " + id), HttpStatus.OK);
     }
 
     /**
@@ -153,7 +107,7 @@ public class PlantController {
      * @return Список процедур
      */
     @GetMapping("/care_types")
-    public List<CareDtoShort> findAllActiveCares() {
+    public List<CareDtoShort> findAllActiveCares() throws Exception {
         return careService.findAllActive();
     }
 }

--- a/module.plant-service/src/main/java/ru/botanica/exceptions/PlantExistsException.java
+++ b/module.plant-service/src/main/java/ru/botanica/exceptions/PlantExistsException.java
@@ -1,0 +1,7 @@
+package ru.botanica.exceptions;
+
+public class PlantExistsException extends Exception{
+    public PlantExistsException(String message) {
+        super(message);
+    }
+}

--- a/module.plant-service/src/main/java/ru/botanica/exceptions/ServerHandleException.java
+++ b/module.plant-service/src/main/java/ru/botanica/exceptions/ServerHandleException.java
@@ -1,0 +1,7 @@
+package ru.botanica.exceptions;
+
+public class ServerHandleException extends Exception {
+    public ServerHandleException(String message) {
+        super(message);
+    }
+}

--- a/module.plant-service/src/main/java/ru/botanica/services/CareService.java
+++ b/module.plant-service/src/main/java/ru/botanica/services/CareService.java
@@ -8,6 +8,7 @@ import ru.botanica.dtos.CareDto;
 import ru.botanica.dtos.CareDtoShort;
 import ru.botanica.entities.Care;
 import ru.botanica.entities.CareSpecifications;
+import ru.botanica.exceptions.ServerHandleException;
 import ru.botanica.mappers.CareDtoMapper;
 import ru.botanica.entities.PlantCare;
 import ru.botanica.dtos.PlantCareDto;
@@ -34,10 +35,14 @@ public class CareService {
      *
      * @return Список процедур
      */
-    public List<CareDtoShort> findAllActive() {
+    public List<CareDtoShort> findAllActive() throws ServerHandleException {
         Specification<Care> specification = createSpecificationsWithFilter(true);
-        return careRepository.findAll(specification).stream()
-                .map(CareDtoMapper::matToDtoShort).toList();
+        try {
+            return careRepository.findAll(specification).stream()
+                    .map(CareDtoMapper::matToDtoShort).toList();
+        } catch (Exception e) {
+            throw new ServerHandleException("Сервер не смог загрузить список процедур из БД");
+        }
     }
 
     /**

--- a/module.plant-service/src/main/java/ru/botanica/services/PlantService.java
+++ b/module.plant-service/src/main/java/ru/botanica/services/PlantService.java
@@ -14,6 +14,8 @@ import ru.botanica.dtos.PlantDto;
 import ru.botanica.dtos.PlantDtoShort;
 import ru.botanica.entities.Plant;
 import ru.botanica.entities.PlantSpecifications;
+import ru.botanica.exceptions.PlantExistsException;
+import ru.botanica.exceptions.ServerHandleException;
 import ru.botanica.mappers.PlantDtoMapper;
 import ru.botanica.repositories.PlantRepository;
 
@@ -46,10 +48,14 @@ public class PlantService {
      * @param pageable Страница(номер страницы, размер страницы)
      * @return Список растений
      */
-    public Page<PlantDtoShort> findAll(String title, Pageable pageable) {
+    public Page<PlantDtoShort> findAll(String title, Pageable pageable) throws ServerHandleException {
         Specification<Plant> specification = createSpecificationsWithFilter(title, true);
-        return plantRepository.findAll(specification, pageable)
-                .map(PlantDtoMapper::mapToDtoShort);
+        try {
+            return plantRepository.findAll(specification, pageable)
+                    .map(PlantDtoMapper::mapToDtoShort);
+        } catch (Exception e) {
+            throw new ServerHandleException("Не удалось загрузить растения из БД");
+        }
     }
 
     /**
@@ -75,8 +81,8 @@ public class PlantService {
      * @param id Идентификатор
      * @return Растение
      */
-    public PlantDto findById(long id) {
-        return PlantDtoMapper.mapToDto(plantRepository.findById(id).orElseThrow());
+    public PlantDto findById(long id) throws PlantExistsException {
+        return PlantDtoMapper.mapToDto(plantRepository.findById(id).orElseThrow(() -> new PlantExistsException("Растения с id " + id + " не существует")));
     }
 
     /**
@@ -86,7 +92,10 @@ public class PlantService {
      * @return Dto растения
      */
     @Transactional
-    public PlantDto updatePlant(PlantDto plantDto) {
+    public PlantDto updatePlant(PlantDto plantDto) throws Exception {
+        if (!isIdExist(plantDto.getId())) {
+            throw new PlantExistsException("Растения c id " + plantDto.getId() + " не существует");
+        }
         Plant plant = plantBuilder
                 .withId(plantDto.getId())
                 .withName(plantDto.getName())
@@ -96,7 +105,12 @@ public class PlantService {
                 .withDescription(plantDto.getDescription())
                 .withIsActive(plantDto.isActive())
                 .build();
-        plantRepository.saveAndFlush(plant);
+        try {
+            plantRepository.saveAndFlush(plant);
+        } catch (Exception e) {
+            throw new ServerHandleException("Не удалось обновить растение. DTO растения: " + plantDto.toString());
+        }
+
         return PlantDtoMapper.mapToDto(addAllOptionsToPlant(plantDto, plant));
     }
 
@@ -110,6 +124,9 @@ public class PlantService {
 
     @Transactional
     public PlantDto addNewPlant(PlantDto plantDto, boolean isOverwriting) throws Exception {
+        if (findByName(plantDto.getName()).isPresent() && !isOverwriting) {
+            throw new PlantExistsException("Растение с именем " + plantDto.getName() + " уже существует");
+        }
         boolean existsByName = plantRepository.existsByName(plantDto.getName());
         Plant plant;
         if (!existsByName) {
@@ -134,9 +151,8 @@ public class PlantService {
                     .build();
             plantRepository.saveAndFlush(plant);
         } else {
-            throw new Exception("Не удалось сохранить растение: " + plantDto.toString());
+            throw new ServerHandleException("Не удалось сохранить растение. DTO растения: " + plantDto);
         }
-
         return PlantDtoMapper.mapToDto(addAllOptionsToPlant(plantDto, plant));
     }
 
@@ -179,10 +195,14 @@ public class PlantService {
      *
      * @param id Идентификатор
      */
-    public PlantDto deletePlantById(long id) {
+    public PlantDto deletePlantById(long id) throws Exception {
         PlantDto plantDto = findById(id);
         plantDto.setActive(false);
-        plantRepository.saveAndFlush(PlantDtoMapper.mapToEntity(plantDto));
+        try {
+            plantRepository.saveAndFlush(PlantDtoMapper.mapToEntity(plantDto));
+        } catch (Exception e) {
+            throw new ServerHandleException("Не удалось удалить растение. Dto растения: " + plantDto.toString());
+        }
         return plantDto;
     }
 
@@ -190,7 +210,11 @@ public class PlantService {
         return plantRepository.findByName(name).map(PlantDtoMapper::mapToDto);
     }
 
-    public boolean isIdExist(Long id) {
-        return plantRepository.existsById(id);
+    public boolean isIdExist(Long id) throws ServerHandleException {
+        try {
+            return plantRepository.existsById(id);
+        } catch (Exception e) {
+            throw new ServerHandleException("Не удалось загрузить список активных действий");
+        }
     }
 }

--- a/module.plant-service/src/main/java/ru/botanica/services/PlantService.java
+++ b/module.plant-service/src/main/java/ru/botanica/services/PlantService.java
@@ -163,17 +163,25 @@ public class PlantService {
      * @param plant    Сохраненная Entity
      * @return Растение с новыми данными
      */
-    private Plant addAllOptionsToPlant(PlantDto plantDto, Plant plant) {
+    private Plant addAllOptionsToPlant(PlantDto plantDto, Plant plant) throws ServerHandleException {
         if (isPhotoPathAvailable(plantDto.getFilePath())) {
-            plant.setPhoto(plantPhotoService.createPhoto(plantDto.getFilePath(), plant.getId()));
+            try {
+                plant.setPhoto(plantPhotoService.createPhoto(plantDto.getFilePath(), plant.getId()));
+            } catch (Exception e) {
+                throw new ServerHandleException("Серверу не удалось сохранить путь к фото");
+            }
         } else {
-            log.warn("Сохранить фото для растения с id= {} не вышло", plant.getId());
+            log.warn("Фото для растения с id= {} отсутствует", plant.getId());
         }
         if (plantDto.getStandardCarePlan() != null && !plantDto.getStandardCarePlan().isEmpty()) {
-            List<PlantCareDto> standardCarePlan = plantDto.getStandardCarePlan();
-            plant.setCares(careService.addAllCaresToPlant(standardCarePlan, PlantDtoMapper.mapToDto(plant)));
+            try {
+                List<PlantCareDto> standardCarePlan = plantDto.getStandardCarePlan();
+                plant.setCares(careService.addAllCaresToPlant(standardCarePlan, PlantDtoMapper.mapToDto(plant)));
+            } catch (Exception e) {
+                throw new ServerHandleException("Серверу не удалось сохранить план ухода для растения");
+            }
         } else {
-            log.warn("Сохранить план ухода для растения с id= {} не вышло", plant.getId());
+            log.warn("План ухода для растения с id= {} отсутствует", plant.getId());
         }
         plant = plantRepository.saveAndFlush(plant);
 

--- a/module.plant-service/src/test/java/ru/botanica/services/PlantServiceTests.java
+++ b/module.plant-service/src/test/java/ru/botanica/services/PlantServiceTests.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import ru.botanica.dtos.PlantCareDto;
 import ru.botanica.dtos.PlantDto;
 import ru.botanica.entities.*;
+import ru.botanica.exceptions.PlantExistsException;
 import ru.botanica.mappers.PlantCareDtoMapper;
 import ru.botanica.repositories.CareRepository;
 import ru.botanica.repositories.PlantCareRepository;
@@ -89,19 +90,22 @@ public class PlantServiceTests {
 
         when(plantRepository.findById(id)).thenReturn(Optional.of(plant));
 
-        PlantDto plantDto = plantService.findById(id);
-
-        assertAll(
-                () -> assertEquals(plant.getId(), plantDto.getId()),
-                () -> assertEquals(plant.getName(), plantDto.getName()),
-                () -> assertEquals(plant.getPhoto().getFilePath(), plantDto.getFilePath()),
-                () -> assertEquals(plant.getGenus(), plantDto.getGenus()),
-                () -> assertEquals(plant.getFamily(), plantDto.getFamily()),
-                () -> assertEquals(plant.getDescription(), plantDto.getDescription()),
-                () -> assertEquals(plant.getShortDescription(), plantDto.getShortDescription()),
-                () -> assertEquals(plant.isActive(), plantDto.isActive()),
-                () -> assertArrayEquals(new PlantCareDto[]{plantCareDto}, plantDto.getStandardCarePlan().toArray())
-        );
+        try {
+            PlantDto plantDto = plantService.findById(id);
+            assertAll(
+                    () -> assertEquals(plant.getId(), plantDto.getId()),
+                    () -> assertEquals(plant.getName(), plantDto.getName()),
+                    () -> assertEquals(plant.getPhoto().getFilePath(), plantDto.getFilePath()),
+                    () -> assertEquals(plant.getGenus(), plantDto.getGenus()),
+                    () -> assertEquals(plant.getFamily(), plantDto.getFamily()),
+                    () -> assertEquals(plant.getDescription(), plantDto.getDescription()),
+                    () -> assertEquals(plant.getShortDescription(), plantDto.getShortDescription()),
+                    () -> assertEquals(plant.isActive(), plantDto.isActive()),
+                    () -> assertArrayEquals(new PlantCareDto[]{plantCareDto}, plantDto.getStandardCarePlan().toArray())
+            );
+        } catch (PlantExistsException e) {
+            e.printStackTrace();
+        }
     }
 
     /**
@@ -123,9 +127,13 @@ public class PlantServiceTests {
 
     @Test
     void testIsIdExists() {
-        long id = 1;
-        when(plantRepository.existsById(id)).thenReturn(true);
-        assertTrue(plantService.isIdExist(id));
+        try {
+            long id = 1;
+            when(plantRepository.existsById(id)).thenReturn(true);
+            assertTrue(plantService.isIdExist(id));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Test


### PR DESCRIPTION
Добавлены кастомные ошибки для ошибок существования растения и обработки данных сервером, добавлена обработка этих ошибок и стандартных ошибок, которые при были получены путем брутфорса через PostConstruct. В связи с добавлением ControllerAdvise, логика из PlantController наконец-то была перенесена в PlantService. Под изменения внесены правки в тесты